### PR TITLE
Fix menu's stack order

### DIFF
--- a/components/menu.tsx
+++ b/components/menu.tsx
@@ -19,8 +19,11 @@ export const Menu = () => {
     <Box
       position="absolute"
       top="0"
+      left="-2px"
       gridArea="1 / -5 / span 1 / -1"
-      width="100%"
+      width="calc(100% + 2px)"
+      zIndex={10}
+      boxShadow="0px 8px 12px rgba(152, 53, 186, 0.22)"
     >
       <ChakraMenu {...disclosure} gutter={0} matchWidth={true}>
         <MenuButton
@@ -30,6 +33,7 @@ export const Menu = () => {
           color="#f2bebe"
           backgroundColor="#FFFAF9"
           width="100%"
+          borderLeft="2px solid #f2bebe"
         >
           <Box
             display="flex"
@@ -51,12 +55,13 @@ export const Menu = () => {
           borderTop="2px solid #f2bebe"
           borderRight="2px solid #f2bebe"
           borderBottom="2px solid #f2bebe"
-          borderLeft="none"
+          borderLeft="2px solid #f2bebe"
           rounded="none"
           background="linear-gradient(180deg, #FFFFFF 0%, #F3FFE9 50.52%, #E7FEFF 100%)"
           p="0"
           width="calc(100% + 2px)"
           minWidth="0"
+          boxShadow="0px 8px 12px rgba(152, 53, 186, 0.22)"
         >
           <Open id="manifesto">
             <MenuItem fontStyle="italic">

--- a/components/menu.tsx
+++ b/components/menu.tsx
@@ -23,7 +23,6 @@ export const Menu = () => {
       gridArea="1 / -5 / span 1 / -1"
       width="calc(100% + 2px)"
       zIndex={10}
-      boxShadow="0px 8px 12px rgba(152, 53, 186, 0.22)"
     >
       <ChakraMenu {...disclosure} gutter={0} matchWidth={true}>
         <MenuButton

--- a/components/menu.tsx
+++ b/components/menu.tsx
@@ -22,7 +22,7 @@ export const Menu = () => {
       left="-2px"
       gridArea="1 / -5 / span 1 / -1"
       width="calc(100% + 2px)"
-      zIndex={10}
+      zIndex={disclosure.isOpen ? 10 : "unset"}
     >
       <ChakraMenu {...disclosure} gutter={0} matchWidth={true}>
         <MenuButton

--- a/components/windows/highlight.tsx
+++ b/components/windows/highlight.tsx
@@ -7,7 +7,7 @@ export const Highlight = () => {
     <Window
       id="highlight"
       defaultIsOpen={true}
-      height="95%"
+      height="80%"
       maxHeight="540px"
       minHeight="350px"
       width="95%"

--- a/components/windows/manifesto.tsx
+++ b/components/windows/manifesto.tsx
@@ -6,7 +6,7 @@ export const Manifesto = () => {
   return (
     <Window
       id="manifesto"
-      height={{ base: "90%", md: "70%" }}
+      height={{ base: "80%", md: "70%" }}
       maxHeight="1000px"
       minHeight="350px"
       width="95%"

--- a/components/windows/radio.tsx
+++ b/components/windows/radio.tsx
@@ -176,7 +176,7 @@ export const Radio = () => {
   return (
     <Window
       id="radio"
-      height="95%"
+      height="80%"
       maxHeight="630px"
       minHeight="350px"
       width="95%"


### PR DESCRIPTION
Problem: menu button and menu list would be behind windows making it hard for users to navigate the website, especially on mobile.

Solution: make menu button and menu list appear on top of windows on click.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/22333399/210184142-60c66f76-6a7d-4f7d-9499-600f3825b001.png"> <img width="371" alt="image" src="https://user-images.githubusercontent.com/22333399/210184100-e91538c9-2993-4420-88cc-fd618a9504e5.png">
